### PR TITLE
Add transient test cases for mori and immutable

### DIFF
--- a/benchmarks/keys.js
+++ b/benchmarks/keys.js
@@ -59,11 +59,8 @@ var immutableKeys = function(keys) {
     for (var i = keys.length - 1; i >= 0; --i)
         h = h.set(keys[i], i);
     
-    // I believe this is the closest translation, but documentation unclear
-    // on what passed and returned by fn.
-    var keys = function key(k, v) { return k; };
     return function() {
-        h.map(keys).toArray();
+        h.keys().toArray();
     };
 };
 

--- a/benchmarks/put_all.js
+++ b/benchmarks/put_all.js
@@ -52,6 +52,24 @@ var immutablePutAll = function(keys) {
     };
 };
 
+var moriPutAllTransient = function(keys) {
+    return function() {
+        var h = mori.mutable.thaw(mori.hash_map());
+        for (var i = 0, len = keys.length; i < len; ++i)
+            h = mori.mutable.assoc(h, keys[i], i);
+        h = mori.mutable.freeze(h);
+    };
+};
+
+var immutablePutAllTransient = function(keys) {
+    return function() {
+        var h = immutable.Map().asMutable();
+        for (var i = 0, len = keys.length; i < len; ++i)
+            h = h.set(keys[i], i);
+        h = h.asImmutable();
+    };
+};
+
 
 module.exports = function(sizes) {
     return sizes.reduce(function(b,size) {
@@ -70,7 +88,13 @@ module.exports = function(sizes) {
                 moriPutAll(keys))
                 
             .add('immutable(' + size+ ')',
-                immutablePutAll(keys));
-            
+                immutablePutAll(keys))
+
+            .add('mori hash_map(' + size+ ') (transient)',
+                moriPutAllTransient(keys))
+
+            .add('immutable(' + size+ ') (transient)',
+                immutablePutAllTransient(keys));
+
     }, new Benchmark.Suite('Put All'));
 };

--- a/benchmarks/remove_all.js
+++ b/benchmarks/remove_all.js
@@ -83,6 +83,32 @@ var immutableRemoveAll = function(keys, order) {
     };
 };
 
+var moriRemoveAllTransient = function(keys, order) {
+    var h = mori.hash_map();
+    for (var i = 0, len = keys.length; i < len; ++i)
+        h = mori.assoc(h, keys[i], i);
+
+    return function() {
+        var c = mori.mutable.thaw(h);
+        for (var i = 0, len = order.length; i < len; ++i)
+           c = mori.mutable.dissoc(c, keys[order[i]]);
+        c = mori.mutable.freeze(c);
+    };
+};
+
+var immutableRemoveAllTransient = function(keys, order) {
+    var h = immutable.Map();
+    for (var i = 0, len = keys.length; i < len; ++i)
+        h = h.set(keys[i], i);
+
+    return function() {
+        var c = h.asMutable();
+        for (var i = 0, len = order.length; i < len; ++i)
+           c = c.delete(keys[order[i]]);
+        c = c.asImmutable();
+    };
+};
+
 
 
 module.exports = function(sizes) {
@@ -103,7 +129,13 @@ module.exports = function(sizes) {
                 moriRemoveAll(keys, order))
             
             .add('immutable(' + size+ ')',
-                immutableRemoveAll(keys, order));
-            
+                immutableRemoveAll(keys, order))
+
+            .add('mori hash_map(' + size+ ') (transient)',
+                moriRemoveAllTransient(keys, order))
+
+            .add('immutable(' + size+ ') (transient)',
+                immutableRemoveAllTransient(keys, order));
+
     }, new Benchmark.Suite('Remove All'));
 };


### PR DESCRIPTION
mori and immutable support transient intermediate tries as a
performance optimization (mori calls this freeze/thaw, immutable calls
this immutable/mutable). This adds test cases illustrating the
performance differences when transience is used.
