### PR TITLE
Add in native variants using Object and Map

### DIFF
--- a/benchmarks/count.js
+++ b/benchmarks/count.js
@@ -13,6 +13,20 @@ var immutable = require('immutable');
 var words = require('./words').words;
 var api = require('./shared');
 
+var nativeObjectCount = function(keys) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    Object.keys(h).length;
+  }
+};
+
+var nativeMapCount = function(keys) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    h.size;
+  };
+};
+
 var hashtrieCount = function(keys) {
     var h = api.hashtrieFrom(keys);
     return function() {
@@ -60,23 +74,29 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b,size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size+ ')',
+                nativeObjectCount(keys))
+
+            .add('nativeMap(' + size+ ')',
+                nativeMapCount(keys))
+
             .add('hashtrie(' + size+ ')',
                 hashtrieCount(keys))
-            
+
             .add('hamt(' + size+ ')',
                 hamtCount(keys))
-            
+
             .add('hamt_plus(' + size+ ')',
                 hamtPlusCount(keys))
-            
+
             .add('persistent-hash-trie(' + size+ ')',
                 pHashtrieCount(keys))
-        
+
             .add('mori hash_map(' + size+ ')',
                 moriCount(keys))
-        
+
             .add('immutable(' + size+ ')',
                 immutableCount(keys));
-            
+
     }, new Benchmark.Suite('Count'));
 };

--- a/benchmarks/get.js
+++ b/benchmarks/get.js
@@ -13,7 +13,21 @@ var immutable = require('immutable');
 var words = require('./words').words;
 var api = require('./shared');
 
+var nativeObjectGet = function(keys) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    var key = keys[Math.floor(Math.random() * keys.length)];
+    h[key];
+  };
+};
 
+var nativeMapGet = function(keys) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    var key = keys[Math.floor(Math.random() * keys.length)];
+    h.get(key);
+  };
+};
 
 var hashtrieGet = function(keys) {
     var h = api.hashtrieFrom(keys);
@@ -69,23 +83,29 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b, size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectGet(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapGet(keys))
+
             .add('hashtrie(' + size + ')',
                 hashtrieGet(keys))
-            
+
             .add('hamt(' + size + ')',
                 hamtGet(keys))
-            
+
            .add('hamt_plus(' + size + ')',
                 hamtPlusGet(keys))
-                
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtrieGet(keys))
-            
+
             .add('mori hash_map(' + size + ')',
                 moriGet(keys))
-          
-          .add('immutable(' + size + ')',
+
+            .add('immutable(' + size + ')',
                 immutableGet(keys));
-            
+
     }, new Benchmark.Suite('Get nth'));
 };

--- a/benchmarks/keys.js
+++ b/benchmarks/keys.js
@@ -13,6 +13,19 @@ var immutable = require('immutable');
 var words = require('./words').words;
 var api = require('./shared');
 
+var nativeObjectKeys = function(keys) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    Object.keys(h);
+  };
+};
+
+var nativeMapKeys = function(keys) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    Array.from(h.keys());
+  };
+};
 
 var hashtrieKeys = function(keys) {
     var h = api.hashtrieFrom(keys);
@@ -62,24 +75,30 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b, size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectKeys(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapKeys(keys))
+
             .add('hashtrie(' + size + ')',
                 hashtrieKeys(keys))
-            
+
             .add('hamt(' + size + ')',
                 hamtKeys(keys))
-            
+
             .add('hamt_plus(' + size + ')',
                 hamtPlusKeys(keys))
-            
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtrieKeys(keys))
-        
+
             .add('mori hash_map(' + size + ')',
                 moriKeys(keys))
-            
+
             .add('immutable(' + size + ')',
                 immutableKeys(keys));
-            
-            
+
+
     }, new Benchmark.Suite('Keys'));
 };

--- a/benchmarks/put.js
+++ b/benchmarks/put.js
@@ -13,6 +13,22 @@ var immutable = require('immutable');
 var words = require('./words').words;
 var api = require('./shared');
 
+var nativeObjectPut = function(keys) {
+  var h = api.nativeObjectFrom(keys.slice(1));
+  var key = keys[0];
+  return function() {
+    Object.assign( {}, h, {[key]: 0});
+  };
+};
+
+var nativeMapPut = function(keys) {
+  var h = api.nativeMapFrom(keys.slice(1));
+  var key = keys[0];
+  return function() {
+    c = new Map( h );
+    c.set(key, 0);
+  };
+};
 
 var hashtriePut = function(keys) {
     var h = api.hashtrieFrom(keys.slice(1));
@@ -67,23 +83,29 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b,size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectPut(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapPut(keys))
+
             .add('hashtrie(' + size + ')',
                 hashtriePut(keys))
-            
+
             .add('hamt(' + size + ')',
                 hamtPut(keys))
-                
+
             .add('hamt_plus(' + size + ')',
                 hamtPlusPut(keys))
-                
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtriePut(keys))
-                
+
             .add('mori hash_map(' + size + ')',
                 moriPut(keys))
-            
+
             .add('immutable(' + size + ')',
                 immutablePut(keys));
-            
+
     }, new Benchmark.Suite('put nth'));
 };

--- a/benchmarks/put.js
+++ b/benchmarks/put.js
@@ -17,7 +17,9 @@ var nativeObjectPut = function(keys) {
   var h = api.nativeObjectFrom(keys.slice(1));
   var key = keys[0];
   return function() {
-    Object.assign( {}, h, {[key]: 0});
+    var newKey = {};
+    newKey[key] = 0;
+    Object.assign({}, h, newKey);
   };
 };
 
@@ -25,7 +27,7 @@ var nativeMapPut = function(keys) {
   var h = api.nativeMapFrom(keys.slice(1));
   var key = keys[0];
   return function() {
-    c = new Map( h );
+    c = new Map(h);
     c.set(key, 0);
   };
 };

--- a/benchmarks/put_all.js
+++ b/benchmarks/put_all.js
@@ -15,8 +15,8 @@ var words = require('./words').words;
 var nativeObjectPutAll = function(keys){
   return function() {
     var h = {};
-    for( var i = 0; i < keys.length; ++i ) {
-      h = Object.assign( {}, h );
+    for( var i = 0, len = keys.length; i < len; ++i ) {
+      h = Object.assign({}, h);
       h[keys[i]] = i;
     }
   };
@@ -25,9 +25,9 @@ var nativeObjectPutAll = function(keys){
 var nativeMapPutAll = function(keys) {
   return function() {
     var h = new Map();
-    for( var i = 0; i < keys.length; ++i ) {
+    for( var i = 0, len = keys.length; i < len; ++i ) {
       h = new Map( h );
-      h.set( keys[i], i );
+      h.set(keys[i], i);
     }
   };
 }

--- a/benchmarks/put_all.js
+++ b/benchmarks/put_all.js
@@ -12,6 +12,23 @@ var immutable = require('immutable');
 
 var words = require('./words').words;
 
+var nativeObjectPutAll = function(keys){
+  return function() {
+    var h = {};
+    for( var i = 0; i < keys.length; ++i ) {
+      h[keys[i]] = i;
+    }
+  };
+};
+
+var nativeMapPutAll = function(keys) {
+  return function() {
+    var h = new Map();
+    for( var i = 0; i < keys.length; ++i ) {
+      h.set( keys[i], i );
+    }
+  };
+}
 
 var hashtriePutAll = function(keys) {
     return function() {
@@ -66,21 +83,27 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b,size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectPutAll(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapPutAll(keys))
+
             .add('hashtrie(' + size + ')',
                 hashtriePutAll(keys))
-            
+
             .add('hamt(' + size + ')',
                 hamtPutAll(keys))
-            
+
              .add('hamt_plus(' + size + ')',
                 hamtPlusPutAll(keys))
-            
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtriePutAll(keys))
-            
+
             .add('mori hash_map(' + size + ')',
                 moriPutAll(keys))
-            
+
             .add('immutable(' + size + ')',
                 immutablePutAll(keys));
 

--- a/benchmarks/put_all.js
+++ b/benchmarks/put_all.js
@@ -16,6 +16,7 @@ var nativeObjectPutAll = function(keys){
   return function() {
     var h = {};
     for( var i = 0; i < keys.length; ++i ) {
+      h = Object.assign( {}, h );
       h[keys[i]] = i;
     }
   };
@@ -25,6 +26,7 @@ var nativeMapPutAll = function(keys) {
   return function() {
     var h = new Map();
     for( var i = 0; i < keys.length; ++i ) {
+      h = new Map( h );
       h.set( keys[i], i );
     }
   };

--- a/benchmarks/put_all_transient.js
+++ b/benchmarks/put_all_transient.js
@@ -16,7 +16,7 @@ var words = require('./words').words;
 var nativeObjectPutAll = function(keys){
   return function() {
     var h = {};
-    for( var i = 0; i < keys.length; ++i ) {
+    for(var i = 0, len = keys.length; i < len; ++i) {
       h[keys[i]] = i;
     }
   };
@@ -25,8 +25,8 @@ var nativeObjectPutAll = function(keys){
 var nativeMapPutAll = function(keys) {
   return function() {
     var h = new Map();
-    for( var i = 0; i < keys.length; ++i ) {
-      h.set( keys[i], i );
+    for(var i = 0, len = keys.length; i < len; ++i) {
+      h.set(keys[i], i);
     }
   };
 }

--- a/benchmarks/put_all_transient.js
+++ b/benchmarks/put_all_transient.js
@@ -1,6 +1,6 @@
 /**
  * @fileOverview Cost to put `n` entries into the hash.
- * 
+ *
  * Uses transiently mutable object interface if possible
  */
 var Benchmark = require('benchmark');
@@ -13,6 +13,23 @@ var immutable = require('immutable');
 
 var words = require('./words').words;
 
+var nativeObjectPutAll = function(keys){
+  return function() {
+    var h = {};
+    for( var i = 0; i < keys.length; ++i ) {
+      h[keys[i]] = i;
+    }
+  };
+};
+
+var nativeMapPutAll = function(keys) {
+  return function() {
+    var h = new Map();
+    for( var i = 0; i < keys.length; ++i ) {
+      h.set( keys[i], i );
+    }
+  };
+}
 
 var hamtPutAll = function(keys) {
     return function() {
@@ -57,17 +74,23 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b,size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectPutAll(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapPutAll(keys))
+
             .add('hamt(' + size + ')',
                 hamtPutAll(keys))
-            
+
             .add('hamt_plus(' + size + ')',
                 hamtPlusPutAll(keys))
-            
+
             .add('mori hash_map(' + size + ')',
                 moriPutAll(keys))
-                
+
             .add('immutable(' + size + ')',
                 immutablePutAll(keys));
-    
+
     }, new Benchmark.Suite('Put All (transient)'));
 };

--- a/benchmarks/remove.js
+++ b/benchmarks/remove.js
@@ -13,7 +13,23 @@ var immutable = require('immutable');
 var words = require('./words').words;
 var api = require('./shared');
 
+var nativeObjectRemove = function(keys) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    var key = keys[Math.floor(Math.random() * keys.length)];
+    var c = Object.assign( {}, h );
+    delete c[key];
+  };
+};
 
+var nativeMapRemove = function(keys) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    var key = keys[Math.floor(Math.random() * keys.length)];
+    var c = new Map(h);
+    c.delete(key);
+  };
+};
 
 var hashtrieRemove = function(keys) {
     var h = api.hashtrieFrom(keys);
@@ -68,23 +84,29 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b,size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectRemove(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapRemove(keys))
+
             .add('hashtrie(' + size + ')',
                 hashtrieRemove(keys))
-            
+
             .add('hamt(' + size + ')',
                 hamtRemove(keys))
-            
+
              .add('hamt_plus(' + size + ')',
                 hamtPlusRemove(keys))
-            
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtrieRemove(keys))
-                
+
             .add('mori hash_map(' + size + ')',
                 moriRemove(keys))
-            
+
             .add('immutable(' + size + ')',
                 immutableRemove(keys));;
-    
+
     }, new Benchmark.Suite('remove nth'));
 };

--- a/benchmarks/remove_all.js
+++ b/benchmarks/remove_all.js
@@ -17,9 +17,10 @@ var api = require('./shared');
 var nativeObjectRemoveAll = function(keys, order) {
   var h = api.nativeObjectFrom(keys);
   return function() {
-    for( var i = 0, len = order.length; i < len; ++i ) {
-      c = Object.assign( {}, h );
-      delete c[ order[i] ];
+    var c;
+    for(var i = 0, len = order.length; i < len; ++i) {
+      c = Object.assign({}, h);
+      delete c[order[i]];
     }
   };
 };
@@ -28,9 +29,9 @@ var nativeMapRemoveAll = function(keys, order) {
   var h = api.nativeMapFrom(keys);
   return function() {
     var c;
-    for( var i = 0, len = order.length; i < len; ++i ) {
-      c = new Map( h );
-      c.delete( order[i] );
+    for(var i = 0, len = order.length; i < len; ++i) {
+      c = new Map(h);
+      c.delete(order[i]);
     }
   };
 };

--- a/benchmarks/remove_all.js
+++ b/benchmarks/remove_all.js
@@ -17,9 +17,9 @@ var api = require('./shared');
 var nativeObjectRemoveAll = function(keys, order) {
   var h = api.nativeObjectFrom(keys);
   return function() {
-    var c;
+    var c = h;
     for(var i = 0, len = order.length; i < len; ++i) {
-      c = Object.assign({}, h);
+      c = Object.assign({}, c);
       delete c[order[i]];
     }
   };
@@ -28,9 +28,9 @@ var nativeObjectRemoveAll = function(keys, order) {
 var nativeMapRemoveAll = function(keys, order) {
   var h = api.nativeMapFrom(keys);
   return function() {
-    var c;
+    var c = h;
     for(var i = 0, len = order.length; i < len; ++i) {
-      c = new Map(h);
+      c = new Map(c);
       c.delete(order[i]);
     }
   };

--- a/benchmarks/remove_all.js
+++ b/benchmarks/remove_all.js
@@ -14,6 +14,30 @@ var words = require('./words').words;
 var range = require('./words').range;
 var api = require('./shared');
 
+var nativeObjectRemoveAll = function(keys, order) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    c = {};
+    for( var k in h ) {
+      if ( h.hasOwnProperty( k ) && order.indexOf( k ) === -1 ) {
+        c[k] = h[k];
+      }
+    }
+  };
+};
+
+var nativeMapRemoveAll = function(keys, order) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    c = new Map();
+    h.forEach( function( val, key ) {
+      if ( order.indexOf( key ) === -1  ) {
+        c.set( key, val );
+      }
+    } );
+  };
+};
+
 var hashtrieRemoveAll = function(keys, order) {
     var h = api.hashtrieFrom(keys);
     return function() {
@@ -74,21 +98,27 @@ module.exports = function(sizes) {
         var keys = words(size, 10),
             order = range(0, size);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectRemoveAll(keys, order))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapRemoveAll(keys, order))
+
             .add('hashtrie(' + size + ')',
                 hashtrieRemoveAll(keys, order))
-            
+
             .add('hamt(' + size + ')',
                 hamtRemoveAll(keys, order))
-            
+
             .add('hamt_plus(' + size + ')',
                 hamtPlusRemoveAll(keys, order))
-                
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtrieRemoveAll(keys, order))
-                
+
             .add('mori hash_map(' + size + ')',
                 moriRemoveAll(keys, order))
-            
+
             .add('immutable(' + size + ')',
                 immutableRemoveAll(keys, order));
 

--- a/benchmarks/remove_all.js
+++ b/benchmarks/remove_all.js
@@ -17,11 +17,9 @@ var api = require('./shared');
 var nativeObjectRemoveAll = function(keys, order) {
   var h = api.nativeObjectFrom(keys);
   return function() {
-    c = {};
-    for( var k in h ) {
-      if ( h.hasOwnProperty( k ) && order.indexOf( k ) === -1 ) {
-        c[k] = h[k];
-      }
+    for( var i = 0, len = order.length; i < len; ++i ) {
+      c = Object.assign( {}, h );
+      delete c[ order[i] ];
     }
   };
 };
@@ -29,12 +27,11 @@ var nativeObjectRemoveAll = function(keys, order) {
 var nativeMapRemoveAll = function(keys, order) {
   var h = api.nativeMapFrom(keys);
   return function() {
-    c = new Map();
-    h.forEach( function( val, key ) {
-      if ( order.indexOf( key ) === -1  ) {
-        c.set( key, val );
-      }
-    } );
+    var c;
+    for( var i = 0, len = order.length; i < len; ++i ) {
+      c = new Map( h );
+      c.delete( order[i] );
+    }
   };
 };
 

--- a/benchmarks/remove_all_transient.js
+++ b/benchmarks/remove_all_transient.js
@@ -17,9 +17,9 @@ var api = require('./shared');
 var nativeObjectRemoveAll = function(keys, order) {
   var h = api.nativeObjectFrom(keys);
   return function() {
-    c = Object.assign( {}, h );
-    for( var i = 0, len = order.length; i < len; ++i ) {
-      delete c[ order[i] ];
+    var c = Object.assign({}, h);
+    for(var i = 0, len = order.length; i < len; ++i) {
+      delete c[order[i]];
     }
   };
 };
@@ -27,9 +27,9 @@ var nativeObjectRemoveAll = function(keys, order) {
 var nativeMapRemoveAll = function(keys, order) {
   var h = api.nativeMapFrom(keys);
   return function() {
-    var c = new Map( h );
-    for( var i = 0, len = order.length; i < len; ++i ) {
-      c.delete( order[i] );
+    var c = new Map(h);
+    for(var i = 0, len = order.length; i < len; ++i) {
+      c.delete(order[i]);
     }
   };
 };

--- a/benchmarks/remove_all_transient.js
+++ b/benchmarks/remove_all_transient.js
@@ -1,6 +1,6 @@
 /**
  * @fileOverview Cost to removed all entries from a hashtrie of size `n`.
- * 
+ *
  * Uses transient mutation if supported.
  */
 var Benchmark = require('benchmark');
@@ -14,6 +14,29 @@ var words = require('./words').words;
 var range = require('./words').range;
 var api = require('./shared');
 
+var nativeObjectRemoveAll = function(keys, order) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    c = {};
+    for( var k in h ) {
+      if ( h.hasOwnProperty( k ) && order.indexOf( k ) === -1 ) {
+        c[k] = h[k];
+      }
+    }
+  };
+};
+
+var nativeMapRemoveAll = function(keys, order) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    c = new Map();
+    h.forEach( function( val, key ) {
+      if ( order.indexOf( key ) === -1  ) {
+        c.set( key, val );
+      }
+    } );
+  };
+};
 
 var hamtRemoveAll = function(keys, order) {
     var h = api.hamtFrom(keys);
@@ -29,7 +52,7 @@ var hamtPlusRemoveAll = function(keys, order) {
         for (var i = 0, len = order.length; i < len; ++i)
             h = hamt_plus.remove(keys[order[i]], h);
     };
-    
+
     var h = api.hamtPlusFrom(keys);
     return function() {
         hamt_plus.mutate(mutate, h);
@@ -63,15 +86,21 @@ module.exports = function(sizes) {
         var keys = words(size, 10),
             order = range(0, size);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectRemoveAll(keys, order))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapRemoveAll(keys, order))
+
             .add('hamt(' + size + ')',
                 hamtRemoveAll(keys, order))
-            
+
            .add('hamt_plus(' + size + ')',
                 hamtPlusRemoveAll(keys, order))
-            
+
             .add('mori hash_map(' + size + ')',
                 moriRemoveAll(keys, order))
-            
+
             .add('immutable(' + size + ')',
                 immutableRemoveAll(keys, order));
 

--- a/benchmarks/remove_all_transient.js
+++ b/benchmarks/remove_all_transient.js
@@ -17,11 +17,9 @@ var api = require('./shared');
 var nativeObjectRemoveAll = function(keys, order) {
   var h = api.nativeObjectFrom(keys);
   return function() {
-    c = {};
-    for( var k in h ) {
-      if ( h.hasOwnProperty( k ) && order.indexOf( k ) === -1 ) {
-        c[k] = h[k];
-      }
+    c = Object.assign( {}, h );
+    for( var i = 0, len = order.length; i < len; ++i ) {
+      delete c[ order[i] ];
     }
   };
 };
@@ -29,12 +27,10 @@ var nativeObjectRemoveAll = function(keys, order) {
 var nativeMapRemoveAll = function(keys, order) {
   var h = api.nativeMapFrom(keys);
   return function() {
-    c = new Map();
-    h.forEach( function( val, key ) {
-      if ( order.indexOf( key ) === -1  ) {
-        c.set( key, val );
-      }
-    } );
+    var c = new Map( h );
+    for( var i = 0, len = order.length; i < len; ++i ) {
+      c.delete( order[i] );
+    }
   };
 };
 

--- a/benchmarks/shared.js
+++ b/benchmarks/shared.js
@@ -5,6 +5,19 @@ var p = require('persistent-hash-trie');
 var mori = require('mori');
 var immutable = require('immutable');
 
+exports.nativeObjectFrom = function(keys) {
+  return keys.reduce( function(map, val, index) {
+    map[val] = index;
+    return map;
+  }, {} );
+}
+
+exports.nativeMapFrom = function(keys) {
+  return keys.reduce( function(map, val, index) {
+    map.set( val, index );
+    return map;
+  }, new Map());
+}
 
 exports.hamtFrom = function(keys) {
     var h = hamt.empty;

--- a/benchmarks/sum.js
+++ b/benchmarks/sum.js
@@ -13,10 +13,31 @@ var immutable = require('immutable');
 var words = require('./words').words;
 var api = require('./shared');
 
+var nativeObjectSum = function(keys) {
+  var h = api.nativeObjectFrom(keys);
+  return function() {
+    var sum = 0;
+    for( var k in h ) {
+      if ( h.hasOwnProperty( k ) ) {
+        sum += h[k];
+      }
+    }
+  };
+};
+
+var nativeMapSum = function(keys) {
+  var h = api.nativeMapFrom(keys);
+  return function() {
+    var sum = 0;
+    h.forEach( function( val, key ) {
+      sum += val;
+    } );
+  };
+};
 
 var hashtrieSum = function(keys) {
     var add = function(p, x) { return p + x; };
-    
+
     var h = api.hashtrieFrom(keys);
     return function() {
         ht.fold(add, 0, h);
@@ -25,7 +46,7 @@ var hashtrieSum = function(keys) {
 
 var hamtSum = function(keys) {
     var add = function(p, x) { return p + x; };
-    
+
     var h = api.hamtFrom(keys);
     return function() {
         hamt.fold(add, 0, h);
@@ -34,7 +55,7 @@ var hamtSum = function(keys) {
 
 var hamtPlusSum = function(keys) {
     var add = function(p, c) { return p + c.value; };
-    
+
     var h = api.hamtPlusFrom(keys);
     return function() {
         hamt_plus.fold(add, 0, h);
@@ -52,7 +73,7 @@ var pHashtrieSum = function(keys) {
 
 var moriSum = function(keys) {
     var add = function(p, _, c) { return p + c; };
-    
+
     var h = api.moriFrom(keys);
     return function() {
         mori.reduceKV(add, 0, h);
@@ -61,7 +82,7 @@ var moriSum = function(keys) {
 
 var immutableSum = function(keys) {
     var add = function(p, c) { return p + c; };
-    
+
     var h = api.immutableFrom(keys);
     return function() {
         h.reduce(add, 0);
@@ -73,23 +94,29 @@ module.exports = function(sizes) {
     return sizes.reduce(function(b, size) {
         var keys = words(size, 10);
         return b
+            .add('nativeObject(' + size + ')',
+                nativeObjectSum(keys))
+
+            .add('nativeMap(' + size + ')',
+                nativeMapSum(keys))
+
             .add('hashtrie(' + size + ')',
                 hashtrieSum(keys))
-            
+
             .add('hamt(' + size + ')',
                 hamtSum(keys))
-            
+
             .add('hamt_plus(' + size + ')',
                 hamtPlusSum(keys))
-            
+
             .add('persistent-hash-trie(' + size + ')',
                 pHashtrieSum(keys))
-            
+
             .add('mori hash_map(' + size + ')',
                 moriSum(keys))
-            
+
             .add('immutable(' + size + ')',
                 immutableSum(keys));
-          
+
     }, new Benchmark.Suite('Sum'));
 };

--- a/package.json
+++ b/package.json
@@ -1,35 +1,33 @@
 {
-    "name": "hashtrie-benchmarks",
-    "version": "0.0.0",
-    "description": "Hash Trie Benchmarks",
-    "keywords": [
-        "trie",
-        "hashtrie",
-        "map",
-        "persistent",
-        "data structure",
-        "hash"
-    ],
-    "author": "Matt Bierner",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/mattbierner/js-hashtrie-benchmark.git"
-    },
-    
-      "dependencies": {
-        "benchmark": "1.0.x",
-        "pad": "0.0.x",
-        
-        "persistent-hash-trie": "0.4.x",
-        "hashtrie": "1.0.x",
-        "hamt": "2.0.x",
-        "hamt_plus": "0.0.x",
-        "mori": "0.3.x",
-        "immutable": "3.7.x"
-    },
-    
-    "scripts": {
-        "benchmark": "node run.js"
-    }
+  "name": "hashtrie-benchmarks",
+  "version": "0.0.0",
+  "description": "Hash Trie Benchmarks",
+  "keywords": [
+    "trie",
+    "hashtrie",
+    "map",
+    "persistent",
+    "data structure",
+    "hash"
+  ],
+  "author": "Matt Bierner",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mattbierner/js-hashtrie-benchmark.git"
+  },
+  "dependencies": {
+    "benchmark": "2.0.x",
+    "hamt": "2.0.x",
+    "hamt_plus": "0.0.x",
+    "hashtrie": "1.0.x",
+    "immutable": "3.7.x",
+    "microtime": "^2.0.0",
+    "mori": "0.3.x",
+    "pad": "1.0.x",
+    "persistent-hash-trie": "0.4.x"
+  },
+  "scripts": {
+    "benchmark": "node run.js"
+  }
 }


### PR DESCRIPTION
This PR adds in native variants of the tests, just to see how hamt-style structures compare.

Also, update dependencies.
